### PR TITLE
Fixed setup.py install circular dependency

### DIFF
--- a/jinjasql/__init__.py
+++ b/jinjasql/__init__.py
@@ -1,6 +1,5 @@
-from jinjasql.core import JinjaSql 
-
 __version__ = '0.1.0'
+
 VERSION = tuple(map(int, __version__.split('.')))
 
 __all__ = ['JinjaSql']


### PR DESCRIPTION
In jinjasql/__init__.py, there was a circular dependency that was not letting Jinja2 to be intalled as a prerequisite.
Removed an unused import statement.