### PR TITLE
More specific python requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ with connection.cursor() as cursor:
 
 Pre-Requisites : 
 
-1. python 2.x and pip.
+1. python 2.6+, or 3.4+, and pip.
 2. jinja2 >= version 2.5
 
 To install from PyPI (recommended) :


### PR DESCRIPTION
The readme had specified 2.x, but makes no mention of 3.x.