### PR TITLE
Use sys.maxsize as upper bound for randrange

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import sys
 from jinja2 import Environment
 from jinja2 import Template
 from jinja2.ext import Extension
@@ -122,7 +123,7 @@ def bind_in_clause(value):
 def _bind_param(already_bound, key, value):
     new_key = key
     while new_key in already_bound:
-        new_key = "%s_%s" % (key, random.randrange(1, 1000))
+        new_key = "%s_%s" % (key, random.randrange(1, sys.maxsize))
     already_bound[new_key] = value
     
     param_style = _thread_local.param_style


### PR DESCRIPTION
It's possible to never exit the [while loop](https://github.com/hashedin/jinjasql/blob/93c9bbceedd45c2439a9b3698e9bddfc5df61958/jinjasql/core.py#L124) if there are more than 1000 items that need to be bound. This PR mitigates it by using `sys.maxsize`, which is Python 2 and 3 compatible. 

There is no real performance penalty by increasing the upper bound of `random.randrange`:
```
%timeit random.randrange(1, 1000)
# 773 ns ± 28.4 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
%timeit random.randrange(1, sys.maxsize)
# 822 ns ± 3.58 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

Reproducing error:
```
import string
import random

def generate_sql(items=None):
    sql_template = """
    SELECT
      col
    FROM
      table
    WHERE
      1
      {% if items %}
      AND table.col IN {{ items | inclause }}
      {% endif %}
    """

    j = JinjaSql()
    data = dict(items=items)
    sql, bind_params = j.prepare_query(sql_template, data)
    return sql, bind_params


def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
    return ''.join(random.choice(chars) for _ in range(size))

# works
generate_sql(items=[id_generator() for _ in range(1000)])
# infinite loop!
generate_sql(items=[id_generator() for _ in range(1001)])
```
