### PR TITLE
Make prepare_query accept a pre-compiled template

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -162,7 +162,11 @@ class JinjaSql(object):
         self.env.filters["inclause"] = bind_in_clause
 
     def prepare_query(self, source, data):
-        template = self.env.from_string(source)
+        if isinstance(source, Template):
+            template = source
+        else:
+            template = self.env.from_string(source)
+
         return self._prepare_query(template, data)
 
     def _prepare_query(self, template, data):

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -48,15 +48,15 @@ class SqlExtension(Extension):
 
     def filter_stream(self, stream):
         """
-        We convert 
+        We convert
         {{ some.variable | filter1 | filter 2}}
-            to 
+            to
         {{ some.variable | filter1 | filter 2 | bind}}
-        
+
         ... for all variable declarations in the template
 
-        This function is called by jinja2 immediately 
-        after the lexing stage, but before the parser is called. 
+        This function is called by jinja2 immediately
+        after the lexing stage, but before the parser is called.
         """
         while not stream.eos:
             token = next(stream)
@@ -68,7 +68,7 @@ class SqlExtension(Extension):
                 variable_end = token
 
                 last_token = var_expr[-1]
-                if (not last_token.test("name") 
+                if (not last_token.test("name")
                     or not last_token.value in ('bind', 'inclause', 'sqlsafe')):
                     param_name = self.extract_param_name(var_expr)
                     # don't bind twice
@@ -83,13 +83,13 @@ class SqlExtension(Extension):
                     yield token
             else:
                 yield token
- 
+
 
 def _bind_param(already_bound, key, value):
     new_key = key
     new_key = "%s#%s" % (key, random.getrandbits(128))
     already_bound[new_key] = value
-    
+
     param_style = _thread_local.param_style
     if param_style == 'qmark':
         return "?"
@@ -157,16 +157,16 @@ class JinjaSql(object):
             del _thread_local.param_index
 
     def bind(self, value, name):
-        """A filter that prints %s, and stores the value 
+        """A filter that prints %s, and stores the value
         in an array, so that it can be bound using a prepared statement
 
-        This filter is automatically applied to every {{variable}} 
+        This filter is automatically applied to every {{variable}}
         during the lexing stage, so developers can't forget to bind
         """
         if isinstance(value, Markup):
             return value
         elif requires_in_clause(value):
-            raise MissingInClauseException("""Got a list or tuple. 
+            raise MissingInClauseException("""Got a list or tuple.
                 Did you forget to apply '|inclause' to your query?""")
         else:
             return _bind_param(_thread_local.bind_params, name, value)
@@ -183,7 +183,7 @@ class JinjaSql(object):
         results = []
         for v in values:
             results.append(_bind_param(_thread_local.bind_params, "inclause", v))
-        
+
         clause = ",".join(results)
         clause = "(" + clause + ")"
         return clause

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -119,10 +119,11 @@ class JinjaSql(object):
     # format "where name = %s"
     # pyformat "where name = %(name)s"
     VALID_PARAM_STYLES = ('qmark', 'numeric', 'named', 'format', 'pyformat')
-    def __init__(self, env=None, param_style='format'):
+    def __init__(self, env=None, param_style='format', extended_array_support=False):
         self.env = env or Environment()
         self._prepare_environment()
         self.param_style = param_style
+        self.extended_array_support = extended_array_support
 
     def _prepare_environment(self):
         self.env.autoescape=True
@@ -165,7 +166,7 @@ class JinjaSql(object):
         """
         if isinstance(value, Markup):
             return value
-        elif requires_in_clause(value):
+        elif requires_in_clause(value) and not self.extended_array_support:
             raise MissingInClauseException("""Got a list or tuple.
                 Did you forget to apply '|inclause' to your query?""")
         else:

--- a/tests/test_jinjasql.py
+++ b/tests/test_jinjasql.py
@@ -78,6 +78,15 @@ class JinjaSqlTest(unittest.TestCase):
         self.assertEquals(len(bind_params), 1)
         self.assertEquals(list(bind_params)[0], 123)
 
+    def test_precompiled_template(self):
+        source = "select * from dummy where project_id = {{ request.project_id }}"
+
+        j = JinjaSql()
+        query, bind_params = j.prepare_query(j.env.from_string(source), _DATA)
+
+        expected_query = "select * from dummy where project_id = %s"
+        self.assertEquals(query.strip(), expected_query.strip())
+
 def generate_yaml_tests():
     file_path = join(YAML_TESTS_ROOT, "macros.yaml")
     with open(file_path) as f:


### PR DESCRIPTION
Without this, the template has to be parsed/interpreted each time. By being able to pass a `Template` instance, you can avoid paying that cost each time.

---

Not sure if a separate function would be preferred. I'll happily change it if needed :) 