### PR TITLE
Make prepare_query accept a pre-compiled template

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -162,7 +162,11 @@ class JinjaSql(object):
         self.env.filters["inclause"] = bind_in_clause
 
     def prepare_query(self, source, data):
-        template = self.env.from_string(source)
+        if isinstance(source, Template):
+            template = source
+        else:
+            template = self.env.from_string(source)
+
         return self._prepare_query(template, data)
 
     def _prepare_query(self, template, data):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 # There are several approaches to eliminate this redundancy,
 # see https://packaging.python.org/single_source_version/
 # but for now, we will simply maintain it in two places
-__version__ = '0.1.7'
+__version__ = '0.1.7-sl.2'
 
 long_description = '''
 Generate SQL Queries using a Jinja Template, without worrying about SQL Injection

--- a/tests/test_jinjasql.py
+++ b/tests/test_jinjasql.py
@@ -78,6 +78,15 @@ class JinjaSqlTest(unittest.TestCase):
         self.assertEquals(len(bind_params), 1)
         self.assertEquals(list(bind_params)[0], 123)
 
+    def test_precompiled_template(self):
+        source = "select * from dummy where project_id = {{ request.project_id }}"
+
+        j = JinjaSql()
+        query, bind_params = j.prepare_query(j.env.from_string(source), _DATA)
+
+        expected_query = "select * from dummy where project_id = %s"
+        self.assertEquals(query.strip(), expected_query.strip())
+
 def generate_yaml_tests():
     file_path = join(YAML_TESTS_ROOT, "macros.yaml")
     with open(file_path) as f:


### PR DESCRIPTION
Without this, the template has to be parsed/interpreted each time. By being able to pass a `Template` instance, you can avoid paying that cost each time.

---

Not sure if a separate function would be preferred. I'll happily change it if needed :) 