### PR TITLE
Add identifier filter to support dynamic and safe insertion of identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,24 @@ select {{column_names | sqlsafe}} from dual
 
 If you use `sqlsafe`, it is your responsibility to ensure there is no sql injection.
 
+Alternatively, the `|identifier` filter can be used to produce escaped strings for safe usage of SQL identifiers such as table or column names. Since the escaping implementation is dependent on the database engine, use the optional constructor argument `db_engine` to control it:
+```python
+template = """
+select {{column1 | identifier}}, {{column2 | identifier}} from {{source | identifier}}
+"""
+j = JinjaSql(db_engine='postgres')
+query, bind_params = j.prepare_query(
+    template, {'column1': 'col1', 'column2': 'col2', 'source': ('a_schema', 'a_table')}
+)
+```
+
+Would result in the following query being rendered:
+```python
+expected_query = """
+select "col1", "col2" from "a_schema"."a_table"
+"""
+```
+
 ## Installing jinjasql ##
 
 Pre-Requisites : 

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -113,7 +113,7 @@ def identifier(value):
         )
 
 def escape_postgres(values):
-    if isintance(values, str):
+    if isinstance(values, str):
         values = (values, )
     def escape_double_quotes(value):
         return value.replace('"', '""')

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -194,6 +194,7 @@ class JinjaSql(object):
         self.env.filters["bind"] = bind
         self.env.filters["sqlsafe"] = sql_safe
         self.env.filters["inclause"] = bind_in_clause
+        self.env.filters["identifier"] = identifier
 
     def prepare_query(self, source, data):
         if isinstance(source, Template):

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -32,7 +32,7 @@ class InvalidBindParameterException(JinjaSqlException):
 
 class SqlExtension(Extension):
     def __init__(self, environment):
-        super().__init__(environment)
+        super(SqlExtension, self).__init__(environment)
         environment.extend(
             db_engine='postgres',
         )
@@ -121,7 +121,7 @@ def identifier(context, *values):
 def escape_postgres(*values):
     def escape_double_quotes(value):
         return value.replace('"', '""')
-    return '.'.join('"{}"'.format(escape_double_quotes(value)) for value in values)
+    return Markup('.'.join('"{}"'.format(escape_double_quotes(value)) for value in values))
 
 def bind(value, name):
     """A filter that prints %s, and stores the value 
@@ -189,7 +189,7 @@ class JinjaSql(object):
         self.param_style = param_style
 
     def _prepare_environment(self):
-        self.env.autoescape=True
+        self.env.autoescape = True
         self.env.add_extension(SqlExtension)
         self.env.add_extension('jinja2.ext.autoescape')
         self.env.filters["bind"] = bind

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -97,14 +97,14 @@ def sql_safe(value):
     in a SQL statement"""
     return Markup(value)
 
-def identifier(*values):
+def identifier(value):
     """A filter that escapes a SQL identifier, usually database objects
     such as tables or fields"""
     available = {
         'postgres': escape_postgres,
     }
     try:
-        return available[_thread_local.db_engine](values)
+        return available[_thread_local.db_engine](value)
     except KeyError:
         raise ValueError(
             'Supported db_engine values are: {}'.format(
@@ -112,7 +112,9 @@ def identifier(*values):
             )
         )
 
-def escape_postgres(*values):
+def escape_postgres(values):
+    if isintance(values, str):
+        values = (values, )
     def escape_double_quotes(value):
         return value.replace('"', '""')
     return Markup('.'.join('"{}"'.format(escape_double_quotes(value)) for value in values))

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -112,9 +112,8 @@ def identifier(value):
             )
         )
 
-def escape_postgres(values):
-    if isinstance(values, str):
-        values = (values, )
+def escape_postgres(tuple_or_str):
+    values = (tuple_or_str, ) if isinstance(tuple_or_str, str) else tuple_or_str
     def escape_double_quotes(value):
         return value.replace('"', '""')
     return Markup('.'.join('"{}"'.format(escape_double_quotes(value)) for value in values))

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -113,7 +113,7 @@ def identifier(value):
         )
 
 def escape_postgres(tuple_or_str):
-    values = (tuple_or_str, ) if isinstance(tuple_or_str, str) else tuple_or_str
+    values = (tuple_or_str, ) if not isinstance(tuple_or_str, tuple) else tuple_or_str
     def escape_double_quotes(value):
         return value.replace('"', '""')
     return Markup('.'.join('"{}"'.format(escape_double_quotes(value)) for value in values))

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -34,7 +34,7 @@ class SqlExtension(Extension):
     def __init__(self, environment):
         super().__init__(environment)
         environment.extend(
-            db_engine='postgres'
+            db_engine='postgres',
         )
 
     def extract_param_name(self, tokens):
@@ -113,14 +113,15 @@ def identifier(context, *values):
         return available[context.eval_ctx.db_engine](values)
     except KeyError:
         raise ValueError(
-            'Supported db_engine values are: '
-            f'{", ".join(context.eval_ctx.db_engine.keys())}'
+            'Supported db_engine values are: {}'.format(
+                ", ".join(context.eval_ctx.db_engine.keys())
+            )
         )
 
 def escape_postgres(*values):
     def escape_double_quotes(value):
         return value.replace('"', '""')
-    return '.'.join(f'"{escape_double_quotes(value)}"' for value in values)
+    return '.'.join('"{}"'.format(escape_double_quotes(value)) for value in values)
 
 def bind(value, name):
     """A filter that prints %s, and stores the value 

--- a/tests/test_jinjasql.py
+++ b/tests/test_jinjasql.py
@@ -102,6 +102,11 @@ class JinjaSqlTest(unittest.TestCase):
         self.assertEquals(len(bind_params), num_of_params)
         self.assertEquals(query, "SELECT 'x' WHERE 'A' in (" + "%s," * (num_of_params - 1) + "%s)")
 
+    def test_invalid_db_engine_raises_exception(self):
+        source = "SELECT {{field | identifier}} from table"
+        j = JinjaSql(db_engine='invalid')
+        self.assertRaises(ValueError, self.j.prepare_query, source, {'field': 'dummy'})
+
 
 def generate_yaml_tests():
     file_path = join(YAML_TESTS_ROOT, "macros.yaml")

--- a/tests/test_jinjasql.py
+++ b/tests/test_jinjasql.py
@@ -16,7 +16,16 @@ _DATA = {
         "columns": "project, timesheet, hours",
         "lt": "<",
         "gt": ">",
-
+    },
+    "ids": {
+        "field1": "id",
+        "field2": "name",
+        "table": "users",
+        "schema": "public",
+    },
+    "malicious": {
+        "table": "users; drop table users; --",
+        "field": "id\" FROM users; drop table users; --"
     },
     "request": {
         "project": {
@@ -64,7 +73,7 @@ class JinjaSqlTest(unittest.TestCase):
 
     def test_include(self):
         where_clause = """where project_id = {{request.project_id}}"""
-        
+
         source = """
         select * from dummy {% include 'where_clause.sql' %}
         """

--- a/tests/test_jinjasql.py
+++ b/tests/test_jinjasql.py
@@ -20,8 +20,7 @@ _DATA = {
     "ids": {
         "field1": "id",
         "field2": "name",
-        "table": "users",
-        "schema": "public",
+        "table": ("public", "users"),
     },
     "malicious": {
         "table": "users; drop table users; --",

--- a/tests/test_jinjasql.py
+++ b/tests/test_jinjasql.py
@@ -105,7 +105,7 @@ class JinjaSqlTest(unittest.TestCase):
     def test_invalid_db_engine_raises_exception(self):
         source = "SELECT {{field | identifier}} from table"
         j = JinjaSql(db_engine='invalid')
-        self.assertRaises(ValueError, self.j.prepare_query, source, {'field': 'dummy'})
+        self.assertRaises(ValueError, j.prepare_query, source, {'field': 'dummy'})
 
 
 def generate_yaml_tests():

--- a/tests/yaml/macros.yaml
+++ b/tests/yaml/macros.yaml
@@ -50,6 +50,18 @@ expected_sql:
     format: SELECT project, timesheet, hours FROM timesheet
 
 ---
+name: test_identifier_filter
+template: SELECT {{ids.field1 | identifier}}, {{ids.field2 | identifier}} FROM {{(ids.schema, ids.table) | identifier}}
+expected_sql:
+    format: SELECT "id", "name" FROM "public"."users"
+
+---
+name: test_identifier_filter_with_malicious_values
+template: SELECT {{malicious.field | identifier}} id FROM {{malicious.table | identifier}}
+expected_sql:
+    format: SELECT "id"" FROM users; drop table users; --" FROM "users; drop table users; --"
+
+---
 name: test_html_characters_are_not_escaped
 template: select 'x' from dual where X {{etc.lt | sqlsafe}} 1
 expected_sql:

--- a/tests/yaml/macros.yaml
+++ b/tests/yaml/macros.yaml
@@ -57,7 +57,7 @@ expected_sql:
 
 ---
 name: test_identifier_filter_with_malicious_values
-template: SELECT {{malicious.field | identifier}} id FROM {{malicious.table | identifier}}
+template: SELECT {{malicious.field | identifier}} FROM {{malicious.table | identifier}}
 expected_sql:
     format: SELECT "id"" FROM users; drop table users; --" FROM "users; drop table users; --"
 

--- a/tests/yaml/macros.yaml
+++ b/tests/yaml/macros.yaml
@@ -51,7 +51,7 @@ expected_sql:
 
 ---
 name: test_identifier_filter
-template: SELECT {{ids.field1 | identifier}}, {{ids.field2 | identifier}} FROM {{(ids.schema, ids.table) | identifier}}
+template: SELECT {{ids.field1 | identifier}}, {{ids.field2 | identifier}} FROM {{ids.table | identifier}}
 expected_sql:
     format: SELECT "id", "name" FROM "public"."users"
 


### PR DESCRIPTION
This PR adds an `identifier` filter to escape SQL identifiers, like table and field names. As mentioned in #32, this would allow for safe and dynamic insertion of table and field names. Currently, this is possible via the `sqlsafe` filter but we delegate the responsibility of escaping strings to the user.

The implementation will depend on database engine, which is why a new `db_engine` parameter was added. I've implemented the filter for escaping strings in Postgres, although I would be willing to include more alternatives in this PR if that's needed to be considered complete. 

On invalid (not implemented or non-existent) engines, a `ValueError` is raised. Should I use instead a new exception inheriting from `JinjaSqlException`?