### PR TITLE
Import Markup from markupsafe

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -3,7 +3,7 @@ from jinja2 import Environment
 from jinja2 import Template
 from jinja2.ext import Extension
 from jinja2.lexer import Token
-from jinja2.utils import Markup
+from markupsafe import Markup
 from collections.abc import Iterable
 
 try:

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -181,7 +181,6 @@ class JinjaSql(object):
     def _prepare_environment(self):
         self.env.autoescape=True
         self.env.add_extension(SqlExtension)
-        self.env.add_extension('jinja2.ext.autoescape')
         self.env.filters["bind"] = bind
         self.env.filters["sqlsafe"] = sql_safe
         self.env.filters["inclause"] = bind_in_clause

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2>=2.5,<3.0
+Jinja2>=2.5
 Django>=1.7,<1.8
 PyYAML>=3
 testcontainers[mysql,postgresql,mssqlserver,oracle]==3.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2>=2.5
+Jinja2>=2.8
 Django>=1.7,<1.8
 PyYAML>=3
 testcontainers[mysql,postgresql,mssqlserver,oracle]==3.4.2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ sdict = {
     'packages' : ['jinjasql'],
     'test_suite' : 'tests.all_tests',
     'install_requires': [
-        'Jinja2>=2.5,<3.0'
+        'Jinja2>=2.5'
     ],
     'classifiers' : [
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ sdict = {
     'packages' : ['jinjasql'],
     'test_suite' : 'tests.all_tests',
     'install_requires': [
-        'Jinja2>=2.5'
+        'Jinja2>=2.8'
     ],
     'classifiers' : [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Closes #50 and closes #44.
We should import `Markup` from `markupsafe` as per this comment: https://github.com/pallets/jinja/issues/1628#issuecomment-1077807079

Additionally we don't need to add the `autoescape` extension as it's already included by default as per this comment: https://github.com/pallets/jinja/issues/1627#issuecomment-1077804247