### PR TITLE
fix: set MarkupSafe version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Jinja2>=2.5,<3.0
 Django>=1.7,<1.8
+MarkupSafe>=2.0,<2.1.0
 PyYAML>=3
 testcontainers[mysql,postgresql,mssqlserver,oracle]==3.4.2


### PR DESCRIPTION
Set `MarkupSafe`'s version range to prevent `ImportError`.

## Background

```bash
$ pip install -r requirements.txt
...
Installing collected packages: pyodbc, Django, cx-Oracle, certifi, wrapt, websocket-client, urllib3, PyYAML, pyparsing, pymysql, psycopg2-binary, MarkupSafe, idna, greenlet, charset-normalizer, sqlalchemy, requests, packaging, Jinja2, docker, deprecation, testcontainers
Successfully installed Django-1.7.11 Jinja2-2.11.3 MarkupSafe-2.1.1 PyYAML-6.0 certifi-2021.10.8 charset-normalizer-2.0.12 cx-Oracle-8.3.0 deprecation-2.1.0 docker-5.0.3 greenlet-1.1.2 idna-3.3 packaging-21.3 psycopg2-binary-2.9.3 pymysql-1.0.2 pyodbc-4.0.32 pyparsing-3.0.9 requests-2.27.1 sqlalchemy-1.4.36 testcontainers-3.4.2 urllib3-1.26.9 websocket-client-1.3.2 wrapt-1.14.1
```

`MarkupSafe-2.1.1` is installed and it drops support of `soft_unicode` in v2.1.0.
(ref. https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0)

It causes the following error.

```bash
$ ./run_tests
Traceback (most recent call last):
  ....
  File "/Users/foo/.virtualenvs/jinjasql/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe'
```

So preventing installing `MarkupSafe` >= 2.1.0 is needed as a first aid.
