### PR TITLE
Fixed broken dependencies and tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Jinja2>=2.5,<3.0
 Django>=1.7,<1.8
 PyYAML>=3
 testcontainers[mysql,postgresql,mssqlserver,oracle]==3.4.2
-markupfafe>=2.0,<2.1.0
+markupsafe>=2.0,<2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Jinja2>=2.5,<3.0
 Django>=1.7,<1.8
 PyYAML>=3
 testcontainers[mysql,postgresql,mssqlserver,oracle]==3.4.2
+markupsafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Jinja2>=2.5,<3.0
 Django>=1.7,<1.8
 PyYAML>=3
 testcontainers[mysql,postgresql,mssqlserver,oracle]==3.4.2
-markupsafe==2.0.1
+markupfafe>=2.0,<2.1.0

--- a/tests/test_real_database.py
+++ b/tests/test_real_database.py
@@ -30,7 +30,7 @@ class PostgresTest(unittest.TestCase):
         """
         query, params = j.prepare_query(template, data)
         with self.engine.connect() as conn:
-            result = conn.execute(query, params).fetchone()
+            result = conn.execute(sqlalchemy.text(query), params).fetchone()
         self.assertTrue(result[0])
     
     def test_quoted_tables(self):
@@ -44,7 +44,7 @@ class PostgresTest(unittest.TestCase):
         """
         query, params = j.prepare_query(template, data)
         with self.engine.connect() as conn:
-            result = conn.execute(query, params).fetchall()
+            result = conn.execute(sqlalchemy.text(query), params).fetchall()
         self.assertEqual(len(result), 1)
 
 class MySqlTest(unittest.TestCase):
@@ -64,7 +64,7 @@ class MySqlTest(unittest.TestCase):
         """
         query, params = j.prepare_query(template, data)
         with self.engine.connect() as conn:
-            result = conn.execute(query, params).fetchall()
+            result = conn.execute(sqlalchemy.text(query), params).fetchall()
         self.assertEqual(len(result), 1)
 
 if __name__ == '__main__':

--- a/tests/test_real_database.py
+++ b/tests/test_real_database.py
@@ -20,7 +20,7 @@ class PostgresTest(unittest.TestCase):
 
     def test_bind_array(self):
         'It should be possible to bind arrays in a query'
-        j = JinjaSql()
+        j = JinjaSql(param_style='named')
         data = {
             "some_num": 1,
             "some_array": [1,2,3]

--- a/tests/test_real_database.py
+++ b/tests/test_real_database.py
@@ -29,7 +29,8 @@ class PostgresTest(unittest.TestCase):
             SELECT {{some_num}} = ANY({{some_array}})
         """
         query, params = j.prepare_query(template, data)
-        result = self.engine.execute(query, params).fetchone()
+        with self.engine.connect() as conn:
+            result = conn.execute(query, params).fetchone()
         self.assertTrue(result[0])
     
     def test_quoted_tables(self):
@@ -42,7 +43,8 @@ class PostgresTest(unittest.TestCase):
             where table_name = 'pg_user'
         """
         query, params = j.prepare_query(template, data)
-        result = self.engine.execute(query, params).fetchall()
+        with self.engine.connect() as conn:
+            result = conn.execute(query, params).fetchall()
         self.assertEqual(len(result), 1)
 
 class MySqlTest(unittest.TestCase):
@@ -61,7 +63,8 @@ class MySqlTest(unittest.TestCase):
             where table_name = 'SESSION_STATUS'
         """
         query, params = j.prepare_query(template, data)
-        result = self.engine.execute(query, params).fetchall()
+        with self.engine.connect() as conn:
+            result = conn.execute(query, params).fetchall()
         self.assertEqual(len(result), 1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
- `markupsafe` made a breaking change but `Jinja2` does not pin to a safe version. Pinned `markupsafe` to a safe version here instead.
- Removed EOL-ed Python versions (3.5 and 3.6) from test matrix.
- Updated tests to be compatible with newer versions of `sqlalchemy`.