### PR TITLE
Fixing MarkUp import error due to deprecated MarkUp module from jinja2

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -3,7 +3,7 @@ from jinja2 import Environment
 from jinja2 import Template
 from jinja2.ext import Extension
 from jinja2.lexer import Token
-from jinja2.utils import Markup
+from markupsafe import Markup
 from collections.abc import Iterable
 
 try:


### PR DESCRIPTION
jinja2 Mark Up has been deprecated resulting in ImportError: cannot import name 'Markup' from 'jinja2.utils'. 
Replaced with import of MarkUp from markupsafe
