### PR TITLE
Fixing Attribute error for autoescape

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -181,7 +181,6 @@ class JinjaSql(object):
     def _prepare_environment(self):
         self.env.autoescape=True
         self.env.add_extension(SqlExtension)
-        self.env.add_extension('jinja2.ext.autoescape')
         self.env.filters["bind"] = bind
         self.env.filters["sqlsafe"] = sql_safe
         self.env.filters["inclause"] = bind_in_clause


### PR DESCRIPTION
AttributeError: module 'jinja2.ext' has no attribute 'autoescape' due to following reason:
Jinja2 3.1, WithExtension and AutoEscapeExtension are built-in now thus are no longer needed.

Removed addition of autoescape extension from JinjaSql object.